### PR TITLE
fix(inspector): terminate stdio server on disconnect

### DIFF
--- a/packages/inspector/src/routes/proxy/stdio.ts
+++ b/packages/inspector/src/routes/proxy/stdio.ts
@@ -50,6 +50,10 @@ const router = new Hono<ProxyEnv>().get(
       webAppTransport.connectWithStream(stream);
       webAppTransport.start();
 
+      // This is to compensate for the lack of the following in SSEHonoTransport:
+      // https://github.com/julibuilds/muppet/blob/ceec9bdadfc7db258513615e5b56c87dd2aadf18/packages/core/src/streaming.ts#L58-L62
+      stream.onAbort(() => webAppTransport.onclose?.());
+
       (serverTransport as StdioClientTransport).stderr!.on("data", (chunk) => {
         webAppTransport.send({
           jsonrpc: "2.0",


### PR DESCRIPTION
`SSEHonoTransport` that was used for the stdio proxy does not relay the underlying stream's close event so its own `onclose` handler never gets called. This then causes the underlying stdio process to be left running even when it was actually disconnected on the other end.

This PR fixes the issue by manually triggering the `onclose` handler when the stream closes. This is a workaround and should be removed when the upstream code referenced in the comment is fixed.
